### PR TITLE
Add Nix Flake for hello_world_tool Crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+/result
+/work_dir
+/db
+/tmp
+/nix
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,163 @@
+{
+  description = ''
+    Here is the crate description including full API documentation:
+
+The `hello_world_tool` crate provides a simple web server implemented using the Axum framework, designed to serve a basic "Hello, World!" response. This crate is intended for use by agents who require a straightforward example of an Axum server setup that they can add endpoints to.
+
+**Modules**
+
+### `hello_world_tool`
+
+The `hello_world_tool` module provides a simple web server implemented using the Axum framework.
+
+#### Functions
+
+##### `hello_world`
+
+```rust
+async fn hello_world() -> &'static str
+```
+
+Returns a "Hello, World!" string.
+
+**Example**
+```rust
+let response = hello_world().await;
+assert_eq!(response, "Hello, World!");
+```
+
+### Errors
+
+The `hello_world_tool` crate uses the `anyhow` crate for error handling. Errors are wrapped in an `anyhow::Error`.
+
+**Configuration**
+
+The server is set up to listen on port `3000` and responds with "Hello, World!" to any requests to the root URL (`/`).
+
+**Running the Server**
+
+To run the server, follow these steps:
+
+1. Ensure you have Rust and Cargo installed.
+2. Clone this repository to your local machine
+3. Run `cargo run` in the project directory
+
+**Testing**
+
+The `hello_world_tool` crate provides a test module for testing the server.
+
+#### `test_hello_world`
+
+```rust
+#[tokio::test]
+async fn test_hello_world() {
+    let addr = setup_server().await;
+
+    let client = reqwest::Client::new();
+    let res = client.get(format!("http://{}", addr)).send().await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.text().await.unwrap(), "Hello, World!");
+}
+```
+
+This test sets up a server, sends a GET request to the root URL, and asserts that the response status is OK and the response body is "Hello, World!".
+  '';
+
+  inputs = {
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-23.11"; };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flakebox = {
+      url = "github:dpc/flakebox?rev=226d584e9a288b9a0471af08c5712e7fac6f87dc";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.fenix.follows = "fenix";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flakebox, fenix, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+        packageName = "hello_world_tool";
+        flakeboxLib = flakebox.lib.${system} { };
+        rustSrc = flakeboxLib.filterSubPaths {
+          root = builtins.path {
+            name = packageName;
+            path = ./.;
+          };
+          paths = [ "Cargo.toml" "Cargo.lock" ".cargo" "src" packageName ];
+        };
+
+        toolchainArgs = let llvmPackages = pkgs.llvmPackages_11;
+        in {
+          extraRustFlags = "--cfg tokio_unstable";
+
+          components = [ "rustc" "cargo" "clippy" "rust-analyzer" "rust-src" ];
+
+          args = {
+            nativeBuildInputs = [ ]
+              ++ lib.optionals (!pkgs.stdenv.isDarwin) [ ];
+          };
+        } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # on Darwin newest stdenv doesn't seem to work
+          # linking rocksdb
+          stdenv = pkgs.clang11Stdenv;
+          clang = llvmPackages.clang;
+          libclang = llvmPackages.libclang.lib;
+          clang-unwrapped = llvmPackages.clang-unwrapped;
+        };
+
+        # all standard toolchains provided by flakebox
+        toolchainsStd = flakeboxLib.mkStdFenixToolchains toolchainArgs;
+
+        toolchainsNative = (pkgs.lib.getAttrs [ "default" ] toolchainsStd);
+
+        toolchainNative =
+          flakeboxLib.mkFenixMultiToolchain { toolchains = toolchainsNative; };
+
+        commonArgs = {
+          buildInputs = [ pkgs.pkg-config pkgs.openssl ]
+            ++ lib.optionals pkgs.stdenv.isDarwin
+            [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ];
+          nativeBuildInputs = [ pkgs.pkg-config ];
+        };
+        outputs = (flakeboxLib.craneMultiBuild { toolchains = toolchainsStd; })
+          (craneLib':
+            let
+              craneLib = (craneLib'.overrideArgs {
+                pname = packageName;
+                src = rustSrc;
+              }).overrideArgs commonArgs;
+            in rec {
+              workspaceDeps = craneLib.buildWorkspaceDepsOnly { };
+              workspaceBuild =
+                craneLib.buildWorkspace { cargoArtifacts = workspaceDeps; };
+              package = craneLib.buildPackageGroup {
+                pname = packageName;
+                packages = [ packageName ];
+                mainProgram = packageName;
+              };
+            });
+      in {
+        legacyPackages = outputs;
+        packages = { default = outputs.package; };
+        devShells = flakeboxLib.mkShells {
+          packages = [ ];
+          buildInputs = commonArgs.buildInputs;
+          nativeBuildInputs = [ commonArgs.nativeBuildInputs ];
+          shellHook = ''
+            export RUSTFLAGS="--cfg tokio_unstable"
+            export RUSTDOCFLAGS="--cfg tokio_unstable"
+            export RUST_LOG="info"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Here is a detailed pull request message based on the provided Git diff:

**Add Nix Flake and `hello_world_tool` Crate**

This pull request introduces a new Nix flake configuration for building and managing the `hello_world_tool` crate, a simple web server implemented using the Axum framework. The crate provides a basic "Hello, World!" response and is designed for use by agents who require a straightforward example of an Axum server setup that they can add endpoints to.

The `hello_world_tool` crate is documented with a description, modules, functions, errors, configuration, and testing information. The Nix flake configuration uses the `nixpkgs` and `fenix` inputs to manage the build process and provides a `devShell` environment for development.

The `.gitignore` file has been updated to ignore the `/result`, `/work_dir`, `/db`, `/tmp`, and `/nix` directories.

Please review and test the changes carefully before merging.