### PR TITLE
Initial Flake.nix Configuration and Gitignore Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+/result
+/work_dir
+/db
+/tmp
+/nix
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,184 @@
+{
+  description = ''
+    Here is the extensive crate description including full API documentation:
+
+**hello_world_tool**
+
+An agent tool for a hello world Axum server.
+
+**API Documentation**
+
+### Functions
+
+#### `hello_world`
+
+ Returns a static string "Hello, World!".
+
+* Returns: `&'static str`
+
+### Macros
+
+ None
+
+### Structs
+
+ None
+
+### Traits
+
+ None
+
+### Enums
+
+ None
+
+### Modules
+
+#### `main`
+
+The main module of the `hello_world_tool` crate.
+
+### Functions
+
+#### `main`
+
+The main entry point of the `hello_world_tool` crate.
+
+* Returns: `Result<(), anyhow::Error>`
+
+### Servers
+
+#### `hello_world_tool`
+
+A simple Axum server that listens on port 3000 and responds with "Hello, World!" to any requests to the root URL (`/`).
+
+### Routes
+
+#### `/`
+
+The root route of the `hello_world_tool` server.
+
+* Method: `GET`
+* Response: `"Hello, World!"`
+* Status Code: `200 OK`
+
+### Testing
+
+The `hello_world_tool` crate comes with a built-in test module.
+
+#### `tests`
+
+A module containing tests for the `hello_world_tool` crate.
+
+### Functions
+
+#### `setup_server`
+
+Sets up a test server and returns the address of the server.
+
+* Returns: `String`
+
+#### `test_hello_world`
+
+A test function that checks if the server responds with "Hello, World!" to a GET request to the root URL (`/`).
+
+Note: This documentation is generated based on the provided Cargo.toml, README, and src/main.rs files.
+  '';
+
+  inputs = {
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-23.11"; };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flakebox = {
+      url = "github:dpc/flakebox?rev=226d584e9a288b9a0471af08c5712e7fac6f87dc";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.fenix.follows = "fenix";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flakebox, fenix, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+        packageName = "hello_world_tool";
+        flakeboxLib = flakebox.lib.${system} { };
+        rustSrc = flakeboxLib.filterSubPaths {
+          root = builtins.path {
+            name = packageName;
+            path = ./.;
+          };
+          paths = [ "Cargo.toml" "Cargo.lock" ".cargo" "src" packageName ];
+        };
+
+        toolchainArgs = let llvmPackages = pkgs.llvmPackages_11;
+        in {
+          extraRustFlags = "--cfg tokio_unstable";
+
+          components = [ "rustc" "cargo" "clippy" "rust-analyzer" "rust-src" ];
+
+          args = {
+            nativeBuildInputs = [ ]
+              ++ lib.optionals (!pkgs.stdenv.isDarwin) [ ];
+          };
+        } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # on Darwin newest stdenv doesn't seem to work
+          # linking rocksdb
+          stdenv = pkgs.clang11Stdenv;
+          clang = llvmPackages.clang;
+          libclang = llvmPackages.libclang.lib;
+          clang-unwrapped = llvmPackages.clang-unwrapped;
+        };
+
+        # all standard toolchains provided by flakebox
+        toolchainsStd = flakeboxLib.mkStdFenixToolchains toolchainArgs;
+
+        toolchainsNative = (pkgs.lib.getAttrs [ "default" ] toolchainsStd);
+
+        toolchainNative =
+          flakeboxLib.mkFenixMultiToolchain { toolchains = toolchainsNative; };
+
+        commonArgs = {
+          buildInputs = [ pkgs.pkg-config pkgs.openssl ]
+            ++ lib.optionals pkgs.stdenv.isDarwin
+            [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ];
+          nativeBuildInputs = [ pkgs.pkg-config ];
+        };
+        outputs = (flakeboxLib.craneMultiBuild { toolchains = toolchainsStd; })
+          (craneLib':
+            let
+              craneLib = (craneLib'.overrideArgs {
+                pname = packageName;
+                src = rustSrc;
+              }).overrideArgs commonArgs;
+            in rec {
+              workspaceDeps = craneLib.buildWorkspaceDepsOnly { };
+              workspaceBuild =
+                craneLib.buildWorkspace { cargoArtifacts = workspaceDeps; };
+              package = craneLib.buildPackageGroup {
+                pname = packageName;
+                packages = [ packageName ];
+                mainProgram = packageName;
+              };
+            });
+      in {
+        legacyPackages = outputs;
+        packages = { default = outputs.package; };
+        devShells = flakeboxLib.mkShells {
+          packages = [ ];
+          buildInputs = commonArgs.buildInputs;
+          nativeBuildInputs = [ commonArgs.nativeBuildInputs ];
+          shellHook = ''
+            export RUSTFLAGS="--cfg tokio_unstable"
+            export RUSTDOCFLAGS="--cfg tokio_unstable"
+            export RUST_LOG="info"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Here is a detailed pull request message based on the provided git diff:

**Title:** Initial flake.nix configuration and updated .gitignore

**Description:**

This pull request introduces a new `flake.nix` configuration, which sets up a comprehensive build and development environment for our project. The configuration includes inputs from `nixpkgs`, `fenix`, `flakebox`, and `flake-utils`, providing a robust foundation for our project's dependencies and tooling.

The `flake.nix` file defines a `hello_world_tool` crate with detailed documentation, including API documentation and test modules. The configuration also sets up a `devShell` with necessary build inputs and environment variables.

In addition to the `flake.nix` configuration, this pull request updates the `.gitignore` file to ignore several directories, including `target`, `result`, `work_dir`, `db`, `tmp`, and `nix`. These changes will help maintain a clean and organized repository.

Please review the changes and let me know if you have any questions or concerns.