### PR TITLE
Add hello_world_tool Flakes with Nix Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+/result
+/work_dir
+/db
+/tmp
+/nix
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,134 @@
+{
+  description = ''
+    "hello_world_tool" is a simple HTTP server built on top of the Axum framework, designed for agents who require a straightforward example of an Axum server setup.
+
+**API Documentation**
+
+### Functions
+
+#### `hello_world`
+
+**Returns**: `&'static str`
+
+A simple function that returns the string "Hello, World!".
+
+### Server
+
+#### `main`
+
+**Returns**: `Result<(), anyhow::Error>`
+
+The main entry point of the server. It sets up a router with a single route for the root URL (`"/"`) using the `hello_world` function, binds a TCP listener to `0.0.0.0:3000`, and starts the server using `axum::serve`.
+
+### Testing
+
+#### `setup_server`
+
+**Returns**: `String`
+
+A test utility function that sets up a server with the same configuration as the main server, but binds to a random available port on `127.0.0.1`. It returns the address of the server as a string.
+
+#### `test_hello_world`
+
+**Returns**: `()`
+
+A test function that sets up a server using `setup_server`, creates a new `reqwest::Client`, sends a GET request to the server, and asserts that the response status is OK and the response text is "Hello, World!".
+  '';
+
+  inputs = {
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-23.11"; };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flakebox = {
+      url = "github:dpc/flakebox?rev=226d584e9a288b9a0471af08c5712e7fac6f87dc";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.fenix.follows = "fenix";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flakebox, fenix, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+        packageName = "hello_world_tool";
+        flakeboxLib = flakebox.lib.${system} { };
+        rustSrc = flakeboxLib.filterSubPaths {
+          root = builtins.path {
+            name = packageName;
+            path = ./.;
+          };
+          paths = [ "Cargo.toml" "Cargo.lock" ".cargo" "src" packageName ];
+        };
+
+        toolchainArgs = let llvmPackages = pkgs.llvmPackages_11;
+        in {
+          extraRustFlags = "--cfg tokio_unstable";
+
+          components = [ "rustc" "cargo" "clippy" "rust-analyzer" "rust-src" ];
+
+          args = {
+            nativeBuildInputs = [ ]
+              ++ lib.optionals (!pkgs.stdenv.isDarwin) [ ];
+          };
+        } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+          # on Darwin newest stdenv doesn't seem to work
+          # linking rocksdb
+          stdenv = pkgs.clang11Stdenv;
+          clang = llvmPackages.clang;
+          libclang = llvmPackages.libclang.lib;
+          clang-unwrapped = llvmPackages.clang-unwrapped;
+        };
+
+        # all standard toolchains provided by flakebox
+        toolchainsStd = flakeboxLib.mkStdFenixToolchains toolchainArgs;
+
+        toolchainsNative = (pkgs.lib.getAttrs [ "default" ] toolchainsStd);
+
+        toolchainNative =
+          flakeboxLib.mkFenixMultiToolchain { toolchains = toolchainsNative; };
+
+        commonArgs = {
+          buildInputs = [ pkgs.pkg-config pkgs.openssl ]
+            ++ lib.optionals pkgs.stdenv.isDarwin
+            [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ];
+          nativeBuildInputs = [ pkgs.pkg-config ];
+        };
+        outputs = (flakeboxLib.craneMultiBuild { toolchains = toolchainsStd; })
+          (craneLib':
+            let
+              craneLib = (craneLib'.overrideArgs {
+                pname = packageName;
+                src = rustSrc;
+              }).overrideArgs commonArgs;
+            in rec {
+              workspaceDeps = craneLib.buildWorkspaceDepsOnly { };
+              workspaceBuild =
+                craneLib.buildWorkspace { cargoArtifacts = workspaceDeps; };
+              package = craneLib.buildPackageGroup {
+                pname = packageName;
+                packages = [ packageName ];
+                mainProgram = packageName;
+              };
+            });
+      in {
+        legacyPackages = outputs;
+        packages = { default = outputs.package; };
+        devShells = flakeboxLib.mkShells {
+          packages = [ ];
+          buildInputs = commonArgs.buildInputs;
+          nativeBuildInputs = [ commonArgs.nativeBuildInputs ];
+          shellHook = ''
+            export RUSTFLAGS="--cfg tokio_unstable"
+            export RUSTDOCFLAGS="--cfg tokio_unstable"
+            export RUST_LOG="info"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Here is a detailed pull request message based on the provided Git diff:

**PR Title:** Add `hello_world_tool` flake with Nix-based build and development environment

**Description:**

This pull request introduces a new `hello_world_tool` flake-based project, built on top of the Axum framework. The flake provides a simple HTTP server with a single route that returns "Hello, World!".

The project includes a comprehensive testing setup, using `reqwest` to send a GET request to the server and assert that the response is successful and contains the expected response text.

To facilitate development, this PR also adds a Nix-based build and development environment, leveraging `flakebox` to manage dependencies and provide a consistent toolchain across different systems. The `flake.nix` file defines inputs, outputs, and a `devShell` configuration, allowing developers to easily set up a working environment with the required dependencies.

**Changes:**

* Added `.gitignore` entries for `/result`, `/work_dir`, `/db`, `/tmp`, and `/nix` directories.
* Created a new `flake.nix` file, defining the `hello_world_tool` flake.
* Set up a Nix-based build and development environment, including `toolchainArgs`, `commonArgs`, and `devShells` configurations.

Please review and test the changes to ensure that they meet your requirements.